### PR TITLE
Updating RabbitMQ.Client to 6.0.0-rc1

### DIFF
--- a/src/Nlog.RabbitMQ.Example/Nlog.RabbitMQ.Example.csproj
+++ b/src/Nlog.RabbitMQ.Example/Nlog.RabbitMQ.Example.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Nlog.RabbitMQ.Example</RootNamespace>
     <AssemblyName>Nlog.RabbitMQ.Example</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
@@ -42,8 +42,9 @@
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NLog.4.5.0-rc03\lib\net45\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RabbitMQ.Client.5.0.1\lib\net451\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce">
+      <HintPath>..\..\packages\RabbitMQ.Client.6.0.0-rc1\lib\net452\RabbitMQ.Client.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/Nlog.RabbitMQ.Example/packages.config
+++ b/src/Nlog.RabbitMQ.Example/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
   <package id="NLog" version="4.5.0-rc03" targetFramework="net451" />
-  <package id="RabbitMQ.Client" version="5.0.1" targetFramework="net451" />
+  <package id="RabbitMQ.Client" version="6.0.0-rc1" targetFramework="net452" />
 </packages>

--- a/src/Nlog.RabbitMQ.Target/Nlog.RabbitMQ.Target.csproj
+++ b/src/Nlog.RabbitMQ.Target/Nlog.RabbitMQ.Target.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.6.1</VersionPrefix>
-    <TargetFrameworks>net451;netstandard1.5</TargetFrameworks>
+    <VersionPrefix>2.7.0</VersionPrefix>
+    <TargetFrameworks>net452;netstandard1.6.1</TargetFrameworks>
 
     <Title>Nlog.RabbitMQ</Title>
     <PackageId>Nlog.RabbitMQ.Target</PackageId>
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.5.0" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0-rc1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
In the new RabbitMQ.Client version, there is no public constructor for the BasicProperties class.